### PR TITLE
Fix pathing bug so `examine_results.rb` can load `./ruby/read_data.rb`

### DIFF
--- a/examine_result.rb
+++ b/examine_result.rb
@@ -9,7 +9,7 @@
 #
 # and a results file
 #  1 2 0.4
-#  2 4 0.6 
+#  2 4 0.6
 #
 # and output
 #  0.4
@@ -20,8 +20,8 @@
 #   van
 
 raise "usage: head -n 500 phrases | ./examine_result.rb some_resemblance_measure.result.500" unless ARGV.size == 1
-
-require 'ruby/read_data'
+$: << File.join(File.dirname(__FILE__), 'ruby')
+require 'read_data'
 data = read_data STDIN
 
 File.open(ARGV.first).each do |line|


### PR DESCRIPTION
This patch fixes a Ruby pathing error where Ruby is unable to load `./ruby/read_data.rb` when running the following commands:

``` bash
% cat test.data | ./ruby/shingle.rb coeff 0.5 > result.1
% cat test.data | ./examine_result.rb result.1
```

The reason for this is because of the line `require 'ruby/read_data'` in the file `./examine_result.rb`. 

The original error, before the change, was:

``` bash
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require': cannot load such file -- ruby/read_data (LoadError)
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from ./examine_result.rb:25:in `<main>'
```

While, the new output works as expected and prints the following to the console:

``` bash
% cat test.data | ./examine_result.rb result.1                                                                                                                                                     
0.72464 (0,2)
    richard's favorite flavour of softdrink is peanut butter and jam
    richard's favorite softdrink flavor is peanut butter and jelly
```

The ruby version I am using, outputted from `ruby --version`, is:

``` bash
ruby 2.0.0p247 (2013-06-27 revision 41674) [universal.x86_64-darwin13]
```
